### PR TITLE
Use PlayerRespawnEvent instead of PlayerDeathEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A plugin the lets players spawn at different locations, depending on their permi
   
   * _multispawn.spawn.SPAWNNAMEHERE_ - allows player to spawn at that spawn
   * _multispawn.noteleport_ - players don't teleport when they join
+  * _multispawn.noteleportondeath_ - players don't teleport when they die
   * _multispawn.bycommand_ - allows usage of /spawn
   * _multispawn.removespawn_ - allows usage of /removespawn
   * _multispawn.others_ - allows you to teleport others to spawn

--- a/src/main/java/com/herocc/bukkit/multispawn/events/PlayerDeath.java
+++ b/src/main/java/com/herocc/bukkit/multispawn/events/PlayerDeath.java
@@ -4,22 +4,24 @@ import com.herocc.bukkit.multispawn.MultiSpawn;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
 
 public class PlayerDeath implements Listener {
   private final MultiSpawn plugin = MultiSpawn.getPlugin();
 
   @EventHandler
   @SuppressWarnings("unused")
-  public void onPlayerDeath(PlayerDeathEvent ev) {
-    final Player p = ev.getEntity();
-    if (p.hasPermission("multispawn.noteleport") // If player is excluded
+  public void onPlayerDeath(PlayerRespawnEvent ev) {
+    final Player p = ev.getPlayer();
+    if (p.hasPermission("multispawn.noteleportondeath") // If player is excluded
       || plugin.getSpawnUtils().getSpawns(p, false).isEmpty()) return; // If spawns are empty
       
     if (plugin.getSpawnUtils().getSpawns(p, true).size() == 1
       && plugin.getSpawnUtils().getSpawns(p, true).contains("default")
       && !plugin.getConfig().getBoolean("useDefaultAsFallback", true)) return;
-    
-    plugin.getSpawnUtils().sendPlayerToSpawn(p); // Teleport player if spawn list isn't empty
+
+    if (!plugin.getSpawnUtils().getSpawns(p, false).isEmpty()) {
+      ev.setRespawnLocation(plugin.getSpawnUtils().getSpawnLocation(plugin.getSpawnUtils().getRandomSpawn(p)));
+    }
   }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -31,6 +31,8 @@ permissions:
     default: false
   multispawn.noteleport:
     default: op
+  multispawn.noteleportondeath:
+    default: op
   multispawn.bycommand.*:
     default: op
   multispawn.removespawn:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,7 +32,7 @@ permissions:
   multispawn.noteleport:
     default: op
   multispawn.noteleportondeath:
-    default: op
+    default: false
   multispawn.bycommand.*:
     default: op
   multispawn.removespawn:


### PR DESCRIPTION
Now it works because the plugin couldn't teleport a player that is currently in 'death screen'.
Also added permission multispawn.noteleportondeath because that would be more flexible to make plugin teleport on join but not teleport on death or vice versa.