### PR TITLE
Add teleportOnJoin and teleportOnDeath to config.yml

### DIFF
--- a/src/main/java/com/herocc/bukkit/multispawn/events/PlayerDeath.java
+++ b/src/main/java/com/herocc/bukkit/multispawn/events/PlayerDeath.java
@@ -14,7 +14,8 @@ public class PlayerDeath implements Listener {
   public void onPlayerDeath(PlayerDeathEvent ev) {
     final Player p = ev.getEntity();
     if (p.hasPermission("multispawn.noteleport") // If player is excluded
-      || plugin.getSpawnUtils().getSpawns(p, false).isEmpty()) return; // If spawns are empty
+        || !plugin.getConfig().getBoolean("teleportOnDeath")
+        || plugin.getSpawnUtils().getSpawns(p, false).isEmpty()) return; // If spawns are empty
       
     if (plugin.getSpawnUtils().getSpawns(p, true).size() == 1
       && plugin.getSpawnUtils().getSpawns(p, true).contains("default")

--- a/src/main/java/com/herocc/bukkit/multispawn/events/PlayerDeath.java
+++ b/src/main/java/com/herocc/bukkit/multispawn/events/PlayerDeath.java
@@ -14,7 +14,7 @@ public class PlayerDeath implements Listener {
   public void onPlayerDeath(PlayerDeathEvent ev) {
     final Player p = ev.getEntity();
     if (p.hasPermission("multispawn.noteleport") // If player is excluded
-        || !plugin.getConfig().getBoolean("teleportOnDeath")
+        || !plugin.getConfig().getBoolean("teleportOnDeath") // If disabled in config.yml
         || plugin.getSpawnUtils().getSpawns(p, false).isEmpty()) return; // If spawns are empty
       
     if (plugin.getSpawnUtils().getSpawns(p, true).size() == 1

--- a/src/main/java/com/herocc/bukkit/multispawn/events/PlayerJoin.java
+++ b/src/main/java/com/herocc/bukkit/multispawn/events/PlayerJoin.java
@@ -16,7 +16,7 @@ public class PlayerJoin implements Listener {
   public void onPlayerJoin(PlayerJoinEvent ev) {
     final Player p = ev.getPlayer();
     if (p.hasPermission("multispawn.noteleport") // If player is excluded
-        || !plugin.getConfig().getBoolean("teleportOnJoin")
+        || !plugin.getConfig().getBoolean("teleportOnJoin") // If disabled in config.yml
         || plugin.getSpawnUtils().getSpawns(p, false).isEmpty()) return; // If spawns are empty
   
     if (plugin.getSpawnUtils().getSpawns(p, true).size() == 1

--- a/src/main/java/com/herocc/bukkit/multispawn/events/PlayerJoin.java
+++ b/src/main/java/com/herocc/bukkit/multispawn/events/PlayerJoin.java
@@ -16,6 +16,7 @@ public class PlayerJoin implements Listener {
   public void onPlayerJoin(PlayerJoinEvent ev) {
     final Player p = ev.getPlayer();
     if (p.hasPermission("multispawn.noteleport") // If player is excluded
+        || !plugin.getConfig().getBoolean("teleportOnJoin")
         || plugin.getSpawnUtils().getSpawns(p, false).isEmpty()) return; // If spawns are empty
   
     if (plugin.getSpawnUtils().getSpawns(p, true).size() == 1

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,6 @@
 spawns: []
 useDefaultAsFallback: true # If the player has no permissions, use the spawn named 'default'
 configversion: 1
+
+teleportOnJoin: true
+teleportOnDeath: false


### PR DESCRIPTION
Now they're configurable in configuration file, that's probably more intuitive than adding permissions to a default group. Permissions still work, though.